### PR TITLE
Replace tab with space to make the error message work

### DIFF
--- a/deploy/platform/kubernetes/features.mk
+++ b/deploy/platform/kubernetes/features.mk
@@ -23,7 +23,7 @@
 include ../../../Makefile.in
 
 ifeq (, $(shell which istioctl))
-	$(error "No istioctl in PATH, please make sure istioctl is available in PATH")
+  $(error "No istioctl in PATH, please make sure istioctl is available in PATH")
 endif
 
 .PHONY: istio


### PR DESCRIPTION
The error message in `ifeq` statement doesn't seem to work if we use tab. Makefile is treating this tab started line as part of a recipe, which is not.