### PR TITLE
fix es cluster yellow

### DIFF
--- a/deploy/platform/kubernetes/feature-cluster/resources.yaml
+++ b/deploy/platform/kubernetes/feature-cluster/resources.yaml
@@ -205,6 +205,8 @@ spec:
               value: elasticsearch
             - name: SW_STORAGE_ES_CLUSTER_NODES
               value: elasticsearch:9200
+            - name: SW_STORAGE_ES_INDEX_REPLICAS_NUMBER
+              value: "0"
             - name: SW_TELEMETRY
               value: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus
             - name: SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS

--- a/deploy/platform/kubernetes/feature-cluster/resources.yaml
+++ b/deploy/platform/kubernetes/feature-cluster/resources.yaml
@@ -115,7 +115,7 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: wait-for-es
-          image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION}
+          image: busybox:1.30
           command:
             - 'sh'
             - '-c'

--- a/deploy/platform/kubernetes/feature-single-node/resources.yaml
+++ b/deploy/platform/kubernetes/feature-single-node/resources.yaml
@@ -155,6 +155,8 @@ spec:
               value: elasticsearch
             - name: SW_STORAGE_ES_CLUSTER_NODES
               value: elasticsearch:9200
+            - name: SW_STORAGE_ES_INDEX_REPLICAS_NUMBER
+              value: "0"
             - name: SW_TELEMETRY
               value: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus
             - name: SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS


### PR DESCRIPTION
In a single es node case, too many `yellow` indices may cause es can not write.

es index `yellow` caused by:
```
the shard cannot be allocated to the same node on which a copy of the shard already exists
```