### PR TITLE
Overhaul istio control plane monitor feature

### DIFF
--- a/deploy/platform/kubernetes/feature-cluster/resources.yaml
+++ b/deploy/platform/kubernetes/feature-cluster/resources.yaml
@@ -204,7 +204,7 @@ spec:
               # @feature: vm; enable vm rules to analyze VM metrics
               # @feature: so11y; enable oap rules to analyze OAP metrics
               # @feature: kubernetes-monitor; enable rules to analyze Kubernetes Cluster/Node/Service metrics
-              # @feature: istio-monitor; enable rules to analyze Istio metrics
+              # @feature: istiod-monitor; enable rules to analyze Istio control plane metrics
               value: vm,oap,k8s-cluster,k8s-node,k8s-service,istio-controlplane
             - name: SW_STORAGE
               value: elasticsearch

--- a/deploy/platform/kubernetes/feature-istiod-monitor/open-telemetry.yaml
+++ b/deploy/platform/kubernetes/feature-istiod-monitor/open-telemetry.yaml
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# @feature: istiod-monitor; set OpenTelemetry config to scrape the Istio control plane metrics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-conf-istio-monitor
+  labels:
+    app: otel-istio-monitor
+data:
+  otel-collector-config: |
+    service:
+      pipelines:
+        metrics:
+          receivers: [ prometheus ]
+          exporters: [ logging, opencensus ]
+    exporters:
+      opencensus:
+        endpoint: "oap:11800"
+        insecure: true
+      logging:
+        loglevel: debug
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          # @feature: istiod-monitor; configuration to scrape Istio control plane metrics
+          - job_name: 'istiod-monitor'
+            kubernetes_sd_configs:
+              - role: endpoints
+            relabel_configs:
+              - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+                action: keep
+                regex: istiod;http-monitoring
+              - action: labelmap
+                regex: __meta_kubernetes_service_label_(.+)
+              - source_labels: []
+                target_label: cluster
+                replacement: skywalking-showcase
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-deployment-istio-monitor
+  labels:
+    app: otel-istio-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-istio-monitor
+  template:
+    metadata:
+      labels:
+        app: otel-istio-monitor
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: otel-sa-istio-monitor
+      containers:
+        - name: otel-istio-monitor
+          image: otel/opentelemetry-collector:0.29.0
+          command:
+            - "/otelcol"
+            - "--config=/conf/otel-collector-config.yaml"
+          volumeMounts:
+            - name: otel-collector-config-vol-istio-monitor
+              mountPath: /conf
+      volumes:
+        - name: otel-collector-config-vol-istio-monitor
+          configMap:
+            name: otel-collector-conf-istio-monitor
+            items:
+              - key: otel-collector-config
+                path: otel-collector-config.yaml

--- a/deploy/platform/kubernetes/feature-istiod-monitor/permissions.yaml
+++ b/deploy/platform/kubernetes/feature-istiod-monitor/permissions.yaml
@@ -15,10 +15,36 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-sa-istio-monitor
 
-.EXPORT_ALL_VARIABLES:
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: otel-role-istio-monitor
+rules:
+  - apiGroups: [ "" ]
+    resources:
+      # @feature: istiod-monitor; permissions to read resources
+      - "endpoints"
+      - "pods"
+      - "services"
+    verbs: [ "get", "watch", "list" ]
 
-NAMESPACE ?= default
-AGENTLESS ?= false
-
-FEATURE_FLAGS ?= agent,cluster,kubernetes-monitor,so11y,vm,als,event,istiod-monitor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-role-binding-istio-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-role-istio-monitor
+subjects:
+  - kind: ServiceAccount
+    name: otel-sa-istio-monitor
+    namespace: ${NAMESPACE}

--- a/deploy/platform/kubernetes/feature-kubernetes-monitor/open-telemetry.yaml
+++ b/deploy/platform/kubernetes/feature-kubernetes-monitor/open-telemetry.yaml
@@ -41,40 +41,6 @@ data:
       prometheus:
         config:
           scrape_configs:
-          # @feature: kubernetes-monitor; configuration to scrape Kubernetes Pods metrics
-          - job_name: kubernetes-pods
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - source_labels: []
-              target_label: cluster
-              replacement: skywalking-showcase
-            - action: keep
-              regex: true
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - action: replace
-              regex: (.+)
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_path
-              target_label: __metrics_path__
-            - action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $$1:$$2
-              source_labels:
-              - __address__
-              - __meta_kubernetes_pod_annotation_prometheus_io_port
-              target_label: __address__
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_namespace
-              target_label: kubernetes_namespace
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: kubernetes_pod_name
           # @feature: kubernetes-monitor; configuration to scrape Kubernetes Nodes metrics
           - job_name: 'kubernetes-cadvisor'
             scheme: https

--- a/deploy/platform/kubernetes/feature-single-node/resources.yaml
+++ b/deploy/platform/kubernetes/feature-single-node/resources.yaml
@@ -151,7 +151,7 @@ spec:
               # @feature: vm; enable vm rules to analyze VM metrics
               # @feature: so11y; enable oap rules to analyze OAP metrics
               # @feature: kubernetes-monitor; enable rules to analyze Kubernetes Cluster/Node/Service metrics
-              # @feature: istio-monitor; enable rules to analyze Istio metrics
+              # @feature: istiod-monitor; enable rules to analyze Istio metrics
               value: vm,oap,k8s-cluster,k8s-node,k8s-service,istio-controlplane
             - name: SW_STORAGE
               value: elasticsearch

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -83,6 +83,7 @@ Currently, the features supported are:
 | `vm`          | Start 2 virtual machines and export their metrics to SkyWalking. | The "virtual machines" are mimicked by Docker containers or Pods. |
 | `als`         | Start microservices WITHOUT SkyWalking agent enabled, and configure SkyWalking to analyze the topology and metrics from their access logs. | Command `istioctl` is required to run this feature. The agentless microservices will be running at namespace `${NAMESPACE}-agentless` |
 | `kubernetes-monitor` | Deploy OpenTelemetry and export Kubernetes monitoring metrics to SkyWalking for analysis and display on UI. | |
+| `istiod-monitor`     | Deploy OpenTelemetry and export Istio control plane metrics to SkyWalking for analysis and display on UI. | |
 | `event`       | Deploy tools to trigger events, and SkyWalking Kubernetes event exporter to export events into SkyWalking. | |
 
 ### Kubernetes


### PR DESCRIPTION
There is an individual job for Istio monitor, and `kubernetes-pods` job is not needed in Kubernetes monitor