### PR TITLE
Replace command `docker-compose` with `docker compose`.

### DIFF
--- a/deploy/platform/docker/Makefile
+++ b/deploy/platform/docker/Makefile
@@ -29,8 +29,8 @@ endif
 
 .PHONY: deploy
 deploy:
-	docker-compose $(features) up -d
+	docker compose $(features) up -d
 
 .PHONY: undeploy
 undeploy:
-	docker-compose $(features) --log-level ERROR down
+	docker compose $(features) down


### PR DESCRIPTION
Start form v2, `docker-compose` has become a plugin of docker.

<https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command>