### PR TITLE
Bump to OAP 9.3.0 RC

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,8 +26,8 @@ TAG ?= $(shell git rev-parse --short HEAD)
 
 ES_IMAGE ?= docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
 
-SW_OAP_IMAGE ?= ghcr.io/apache/skywalking/oap:067b119716970a323fa0233d6f2044c368fb6cd5
-SW_UI_IMAGE ?= ghcr.io/apache/skywalking/ui:067b119716970a323fa0233d6f2044c368fb6cd5
+SW_OAP_IMAGE ?= ghcr.io/apache/skywalking/oap:a7922d6fd988277c31e9bc94ddb6c6b72d2b2160
+SW_UI_IMAGE ?= ghcr.io/apache/skywalking/ui:a7922d6fd988277c31e9bc94ddb6c6b72d2b2160
 SW_CLI_IMAGE ?= ghcr.io/apache/skywalking-cli/skywalking-cli:ec85225f3fc0d0d7e8a9513b828d305c7cb399ad
 SW_EVENT_EXPORTER_IMAGE ?= ghcr.io/apache/skywalking-kubernetes-event-exporter/skywalking-kubernetes-event-exporter:8a012a3f968cb139f817189afb9b3748841bba22
 SW_AGENT_JAVA_IMAGE ?= ghcr.io/apache/skywalking-java/skywalking-java:51161ae6a5b8e266eef39162cc4e23440d36ab38-java8


### PR DESCRIPTION
TODO list
1. @mrproliu update the showcase and deployment(demo-install) to demonstrate network profiling for HTTP 1.x and request sampling
2. One `indexing-only` attribute bug in the ElasticSearch storage option. @wankai123 
3. A small UI enhancement to show `ns` of the span event. @Fine0830 