### PR TITLE
Forward Zipkin headers in services and enable Zipkin traces in agentless namespace

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,8 +26,8 @@ TAG ?= $(shell git rev-parse --short HEAD)
 
 ES_IMAGE ?= docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
 
-SW_OAP_IMAGE ?= ghcr.io/apache/skywalking/oap:4ee8389b5cc881883480a7120fe5b57e51091451
-SW_UI_IMAGE ?= ghcr.io/apache/skywalking/ui:4ee8389b5cc881883480a7120fe5b57e51091451
+SW_OAP_IMAGE ?= ghcr.io/apache/skywalking/oap:c484e3ec057f5fbaa34755ab750020acd5138449
+SW_UI_IMAGE ?= ghcr.io/apache/skywalking/ui:c484e3ec057f5fbaa34755ab750020acd5138449
 SW_CLI_IMAGE ?= ghcr.io/apache/skywalking-cli/skywalking-cli:0883266bfaa36612927b69e35781b64ea181758d
 SW_EVENT_EXPORTER_IMAGE ?= ghcr.io/apache/skywalking-kubernetes-event-exporter/skywalking-kubernetes-event-exporter:8a012a3f968cb139f817189afb9b3748841bba22
 SW_AGENT_JAVA_IMAGE ?= ghcr.io/apache/skywalking-java/skywalking-java:51161ae6a5b8e266eef39162cc4e23440d36ab38-java8

--- a/deploy/platform/kubernetes/feature-cluster/resources.yaml
+++ b/deploy/platform/kubernetes/feature-cluster/resources.yaml
@@ -75,7 +75,9 @@ spec:
       port: 11800
     - name: http
       port: 12800
-    - name: zipkin
+    - name: zipkin-receiver
+      port: 9411
+    - name: zipkin-query
       port: 9412
 
 ---
@@ -189,6 +191,10 @@ spec:
               containerPort: 11800
             - name: http
               containerPort: 12800
+            - name: zipkin-receiver
+              containerPort: 9411
+            - name: zipkin-query
+              containerPort: 9412
           env:
             - name: JAVA_OPTS
               value: "-Dmode=no-init"

--- a/deploy/platform/kubernetes/feature-single-node/resources.yaml
+++ b/deploy/platform/kubernetes/feature-single-node/resources.yaml
@@ -74,7 +74,9 @@ spec:
       port: 11800
     - name: http
       port: 12800
-    - name: zipkin
+    - name: zipkin-receiver
+      port: 9411
+    - name: zipkin-query
       port: 9412
 
 ---
@@ -115,6 +117,10 @@ spec:
               containerPort: 11800
             - name: http
               containerPort: 12800
+            - name: zipkin-receiver
+              containerPort: 9411
+            - name: zipkin-query
+              containerPort: 9412
           env:
             - name: SW_CLUSTER_K8S_NAMESPACE
               value: ${NAMESPACE}

--- a/deploy/platform/kubernetes/features.mk
+++ b/deploy/platform/kubernetes/features.mk
@@ -40,7 +40,10 @@ istio: istioctl
 		--set 'meshConfig.defaultConfig.proxyStatsMatcher.inclusionRegexps[6]=.*lb_healthy_panic.*' \
 		--set 'meshConfig.defaultConfig.proxyStatsMatcher.inclusionRegexps[7]=.*upstream_cx_none_healthy.*' \
 		--set meshConfig.defaultConfig.envoyMetricsService.address=$(BACKEND_SERVICE).$(NAMESPACE):11800 `# @feature: als; set MetricsService address to Backend Service so Envoy emits metrics to Backend Service` \
-		--set meshConfig.defaultConfig.envoyAccessLogService.address=$(BACKEND_SERVICE).$(NAMESPACE):11800 `# @feature: als; set AccessLogService address to Backend Service so Envoy emits logs to Backend Service`
+		--set meshConfig.defaultConfig.envoyAccessLogService.address=$(BACKEND_SERVICE).$(NAMESPACE):11800 `# @feature: als; set AccessLogService address to Backend Service so Envoy emits logs to Backend Service` \
+		--set meshConfig.defaultConfig.tracing.sampling=100 \
+		--set meshConfig.defaultConfig.tracing.zipkin.address=$(BACKEND_SERVICE).$(NAMESPACE).svc.cluster.local:9411 \
+		--set meshConfig.enableTracing=true
 
 .PHONY: namespace
 namespace:

--- a/services/app/server/src/index.agentless.js
+++ b/services/app/server/src/index.agentless.js
@@ -26,8 +26,15 @@ const GATEWAY = process.env.GATEWAY || 'gateway';
 const app = express();
 
 app.get('/homepage', async (req, res) => {
-    const top = await axios.get(`http://${GATEWAY}/songs/top`);
-    const rcmd = await axios.get(`http://${GATEWAY}/rcmd`);
+    const headers = {};
+    for (const header in ['x-b3-traceid', 'x-b3-spanid', 'x-b3-parentspanid', 'x-b3-sampled', 'x-b3-flags']) {
+        if (req.headers[header]) {
+            headers[header] = req.headers[header];
+        }
+    }
+
+    const top = await axios.get(`http://${GATEWAY}/songs/top`, { headers });
+    const rcmd = await axios.get(`http://${GATEWAY}/rcmd`, { headers });
 
     res.json({
         top: top.data,

--- a/services/recommendation-service/src/app.py
+++ b/services/recommendation-service/src/app.py
@@ -19,7 +19,7 @@ import os
 import requests
 
 if __name__ == '__main__':
-    from flask import Flask, jsonify
+    from flask import Flask, jsonify, request
 
     app = Flask(__name__)
 
@@ -31,7 +31,19 @@ if __name__ == '__main__':
 
     @app.route('/rcmd', methods=['GET'])
     def application():
-        r = requests.get('http://songs/songs')
+        headers = {}
+        for key in [
+            'x-b3-traceid',
+            'x-b3-spanid',
+            'x-b3-parentspanid',
+            'x-b3-sampled',
+            'x-b3-flags',
+        ]:
+            val = request.headers.get(key)
+            if val is not None:
+                headers[key] = request.headers[key]
+
+        r = requests.get('http://songs/songs', headers=headers)
         recommendations = r.json()
         return jsonify(recommendations)
 


### PR DESCRIPTION
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/15965696/211308290-a9af94a1-e0a1-47c2-901e-954ba01be38b.png">

<img width="1673" alt="image" src="https://user-images.githubusercontent.com/15965696/211308575-5e5836fd-b8b8-4d0e-8679-e000074577d9.png">

This is not perfect because some components like APISIX are not configured to forward the Zipkin headers and it needs some more pull requests to make the trace complete, others who are familiar with APISIX are welcome to enhance this.