### PR TITLE
Make the songs service use Undertow as web container

### DIFF
--- a/services/songs-service/build.gradle
+++ b/services/songs-service/build.gradle
@@ -38,7 +38,10 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation('org.springframework.boot:spring-boot-starter-web') {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+	}
+	implementation 'org.springframework.boot:spring-boot-starter-undertow'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'com.h2database:h2'


### PR DESCRIPTION
Change the network container of songs to use the `Undertow` framework, so that multiple segments can be simulated when Trace Profiling.