### PR TITLE
fix wrong env name for enabledOtelMetricsRules in OAP

### DIFF
--- a/deploy/platform/docker/docker-compose.cluster.yaml
+++ b/deploy/platform/docker/docker-compose.cluster.yaml
@@ -53,7 +53,7 @@ services:
       SW_CLUSTER_ZK_HOST_PORT: zookeeper:2181 # @feature: cluster; set up the cluster coordinator address
       SW_HEALTH_CHECKER: default # @feature: health-check;
       SW_OTEL_RECEIVER: default # @feature: vm; enable the OC receiver that receives the VM metrics
-      SW_OTEL_RECEIVER_ENABLED_OTEL_RULES: vm,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/* # @feature: vm; enable the OC rules that analyse the VM metrics
+      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/* # @feature: vm; enable the OC rules that analyse the VM metrics
       SW_STORAGE: elasticsearch
       SW_STORAGE_ES_CLUSTER_NODES: elasticsearch:9200
       SW_TELEMETRY: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus

--- a/deploy/platform/docker/docker-compose.single-node.yaml
+++ b/deploy/platform/docker/docker-compose.single-node.yaml
@@ -43,7 +43,7 @@ services:
     environment:
       SW_HEALTH_CHECKER: default # @feature: health-check;
       SW_OTEL_RECEIVER: default # @feature: vm; enable the OC receiver that receives the VM metrics
-      SW_OTEL_RECEIVER_ENABLED_OTEL_RULES: vm,mysql/*,postgresql/*,elasticsearch/*,rabbitmq/*,mongodb/* # @feature: vm,mysql,postgresql,elasticsearch; enable the OC rules that analyse the metrics
+      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,mysql/*,postgresql/*,elasticsearch/*,rabbitmq/*,mongodb/* # @feature: vm,mysql,postgresql,elasticsearch; enable the OC rules that analyse the metrics
       SW_STORAGE: elasticsearch
       SW_STORAGE_ES_CLUSTER_NODES: elasticsearch:9200
       SW_TELEMETRY: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus

--- a/deploy/platform/kubernetes/values.yaml
+++ b/deploy/platform/kubernetes/values.yaml
@@ -40,7 +40,7 @@ skywalking:
       # @feature: istiod-monitor; enable rules to analyze Istio control plane metrics
       # @feature: mysql; enable mysql rules to analyze MySQL metrics
       # @feature: apisix-monitor; enable APISIX rules to analyze APISIX metrics
-      SW_OTEL_RECEIVER_ENABLED_OTEL_RULES: vm,oap,k8s/*,istio-controlplane,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/*,nginx/*
+      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,oap,k8s/*,istio-controlplane,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/*,nginx/*
       SW_TELEMETRY: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus
       SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS: "mx-mesh,persistence" # @feature: als; enable mesh analyzer (mx-mesh) to analyze ALS logs
       K8S_SERVICE_NAME_RULE: "mesh-svr::${service.metadata.name}"


### PR DESCRIPTION
https://github.com/apache/skywalking/blob/0f2570a5c9d5069b4168d8f6bc75cc3e4ed3fcf3/oap-server/server-starter/src/main/resources/application.yml#L347C5-L347C28