### PR TITLE
Add ActiveMQ monitor showcase

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,10 +29,10 @@ ES_IMAGE ?= docker.elastic.co/elasticsearch/elasticsearch-oss
 ES_IMAGE_TAG ?= 7.10.2
 
 SW_OAP_IMAGE ?= ghcr.io/apache/skywalking/oap
-SW_OAP_IMAGE_TAG ?= 0b9bbb47b3bedb78d016f9654c2f447c69b3bf7f
+SW_OAP_IMAGE_TAG ?= b3044ee71464c117ffcbf80a5b669da0ad64c260
 
 SW_UI_IMAGE ?= ghcr.io/apache/skywalking/ui
-SW_UI_IMAGE_TAG ?= 0b9bbb47b3bedb78d016f9654c2f447c69b3bf7f
+SW_UI_IMAGE_TAG ?= b3044ee71464c117ffcbf80a5b669da0ad64c260
 
 SW_CLI_IMAGE ?= ghcr.io/apache/skywalking-cli/skywalking-cli:0883266bfaa36612927b69e35781b64ea181758d
 SW_EVENT_EXPORTER_IMAGE ?= ghcr.io/apache/skywalking-kubernetes-event-exporter/skywalking-kubernetes-event-exporter:8a012a3f968cb139f817189afb9b3748841bba22

--- a/deploy/platform/docker/Makefile.in
+++ b/deploy/platform/docker/Makefile.in
@@ -17,4 +17,4 @@
 #
 
 .EXPORT_ALL_VARIABLES:
-FEATURE_FLAGS ?= agent,cluster,so11y,vm-monitor,event,mysql-monitor,nginx-monitor,apisix-monitor,grafana,elasticsearch-monitor,pulsar-monitor
+FEATURE_FLAGS ?= agent,cluster,so11y,vm-monitor,event,mysql-monitor,nginx-monitor,apisix-monitor,grafana,elasticsearch-monitor,pulsar-monitor,activemq-monitor

--- a/deploy/platform/docker/config/activemq/activemq.xml
+++ b/deploy/platform/docker/config/activemq/activemq.xml
@@ -1,0 +1,70 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans
+    xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="${ACTIVEMQ_BROKER_NAME}" dataDirectory="${activemq.data}">
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" >
+                  <pendingMessageLimitStrategy>
+                    <constantPendingMessageLimitStrategy limit="1000"/>
+                  </pendingMessageLimitStrategy>
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+        <transportConnectors>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+      </broker>
+      <import resource="jetty.xml"/>
+</beans>

--- a/deploy/platform/docker/config/activemq/config.yaml
+++ b/deploy/platform/docker/config/activemq/config.yaml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+startDelaySeconds: 10
+hostPort: activemq:1616
+username: admin
+password: activemq
+ssl: false
+lowercaseOutputName: false
+lowercaseOutputLabelNames: false
+includeObjectNames: ["org.apache.activemq:*","java.lang:type=OperatingSystem","java.lang:type=GarbageCollector,*","java.lang:type=Threading","java.lang:type=Runtime","java.lang:type=Memory","java.lang:name=*"]
+excludeObjectNames: ["org.apache.activemq:type=ColumnFamily,*"]
+autoExcludeObjectNameAttributes: true
+excludeObjectNameAttributes:
+  "java.lang:type=OperatingSystem":
+    - "ObjectName"
+  "java.lang:type=Runtime":
+    - "ClassPath"
+    - "SystemProperties"
+rules:
+- pattern: ".*"

--- a/deploy/platform/docker/config/activemq/otel-collector-config.yaml
+++ b/deploy/platform/docker/config/activemq/otel-collector-config.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "activemq-monitoring"
+          scrape_interval: 10s
+          static_configs:
+            - targets: ['${OTEL_TARGET_ADDREESS}']
+              labels:
+                cluster: activemq-cluster
+
+exporters:
+  otlp:
+    endpoint: '${SW_AGENT_COLLECTOR_BACKEND_SERVICES}'
+    tls:
+      insecure: true
+
+processors:
+  batch:
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus
+      processors:
+        - batch
+      exporters:
+        - otlp

--- a/deploy/platform/docker/docker-compose.activemq-monitor.yaml
+++ b/deploy/platform/docker/docker-compose.activemq-monitor.yaml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "2.1"
+
+services:
+  amqexporter:
+    image: bitnami/jmx-exporter:0.20.0
+    hostname: amqexporter
+    volumes:
+      - ./config/activemq/config.yaml:/opt/bitnami/jmx-exporter/example_configs/httpserver_sample_config.yml
+    expose:
+      - 5556
+    depends_on:
+      activemq:
+        condition: service_healthy
+    networks:
+      - sw
+
+  otel-collector:
+    image: ${OTEL_COLLECTOR_IMAGE}:${OTEL_COLLECTOR_VERSION}
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: ${BACKEND_SERVICE}:11800
+      OTEL_TARGET_ADDREESS: amqexporter:5556
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - ./config/activemq/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+    networks:
+      - sw
+
+networks:
+  sw:

--- a/deploy/platform/docker/docker-compose.agent.yaml
+++ b/deploy/platform/docker/docker-compose.agent.yaml
@@ -109,6 +109,13 @@ services:
       
   activemq:
     image: rmohr/activemq:5.15.9
+    environment:
+      ACTIVEMQ_SUNJMX_START: "-Dcom.sun.management.jmxremote.port=1616 -Dcom.sun.management.jmxremote.rmi.port=1616 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+      ACTIVEMQ_BROKER_NAME: activemq-broker
+    expose:
+      - 1616:1616
+    volumes:
+      - ./config/activemq/activemq.xml:/opt/activemq/conf/activemq.xml
     networks: [ sw ]
     healthcheck:
       test: [ "CMD-SHELL", "curl http://localhost:8161" ]

--- a/deploy/platform/docker/docker-compose.cluster.yaml
+++ b/deploy/platform/docker/docker-compose.cluster.yaml
@@ -53,7 +53,7 @@ services:
       SW_CLUSTER_ZK_HOST_PORT: zookeeper:2181 # @feature: cluster; set up the cluster coordinator address
       SW_HEALTH_CHECKER: default # @feature: health-check;
       SW_OTEL_RECEIVER: default # @feature: vm; enable the OC receiver that receives the VM metrics
-      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/*,rocketmq/*,pulsar/* # @feature: vm; enable the OC rules that analyse the VM metrics
+      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/*,rocketmq/*,pulsar/*,activemq/* # @feature: vm; enable the OC rules that analyse the VM metrics
       SW_STORAGE: elasticsearch
       SW_STORAGE_ES_CLUSTER_NODES: elasticsearch:9200
       SW_TELEMETRY: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus

--- a/deploy/platform/docker/docker-compose.single-node.yaml
+++ b/deploy/platform/docker/docker-compose.single-node.yaml
@@ -43,7 +43,7 @@ services:
     environment:
       SW_HEALTH_CHECKER: default # @feature: health-check;
       SW_OTEL_RECEIVER: default # @feature: vm; enable the OC receiver that receives the VM metrics
-      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,mysql/*,postgresql/*,elasticsearch/*,rabbitmq/*,mongodb/*,rocketmq/*,pulsar/* # @feature: vm,mysql,postgresql,elasticsearch; enable the OC rules that analyse the metrics
+      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,mysql/*,postgresql/*,elasticsearch/*,rabbitmq/*,mongodb/*,rocketmq/*,pulsar/*,activemq/* # @feature: vm,mysql,postgresql,elasticsearch; enable the OC rules that analyse the metrics
       SW_STORAGE: elasticsearch
       SW_STORAGE_ES_CLUSTER_NODES: elasticsearch:9200
       SW_TELEMETRY: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus

--- a/deploy/platform/kubernetes/Makefile
+++ b/deploy/platform/kubernetes/Makefile
@@ -187,6 +187,11 @@ feature-pulsar-monitor:
 	$(eval HELM_OPTIONS := $(HELM_OPTIONS) --set features.pulsarMonitor.enabled=true)
 	$(eval HELM_OPTIONS := $(HELM_OPTIONS) --set opentelemetry.enabled=true)
 
+.PHONY: feature-activemq-monitor
+feature-activemq-monitor:
+	$(eval HELM_OPTIONS := $(HELM_OPTIONS) --set features.activemqMonitor.enabled=true)
+	$(eval HELM_OPTIONS := $(HELM_OPTIONS) --set opentelemetry.enabled=true)
+
 .PHONY: deploy
 deploy: $(features)
 	helm dep up .

--- a/deploy/platform/kubernetes/templates/feature-activemq-monitor/opentelemetry-config.yaml
+++ b/deploy/platform/kubernetes/templates/feature-activemq-monitor/opentelemetry-config.yaml
@@ -16,11 +16,24 @@
 # under the License.
 #
 
-.EXPORT_ALL_VARIABLES:
+{{- define "opentelemetry-config-activemq-monitor" }}
+{{- if .Values.features.activemqMonitor.enabled }}
 
-NAMESPACE ?= skywalking-showcase
-SAMPLE_SERVICES_NAMESPACE ?= sample-services
-RELEASE ?= demo
-AGENTLESS ?= false
+- job_name: activemq-monitoring
+  scrape_interval: 10s
+  kubernetes_sd_configs:
+    - role: pod
+  relabel_configs:
+    - source_labels: [ __meta_kubernetes_pod_container_name, __meta_kubernetes_pod_container_port_name ]
+      action: keep
+      regex: activemq-exporter;metrics
+    - source_labels: [ ]
+      target_label: cluster
+      replacement: activemq.{{ .Values.sampleServices.namespace }}
+    - source_labels: [ __meta_kubernetes_pod_name ]
+      target_label: service_instance_id
+      regex: (.+)
+      replacement: $$1
 
-FEATURE_FLAGS ?= java-agent-injector,cluster,elasticsearch,kubernetes-monitor,so11y,vm-monitor,als,event,istiod-monitor,satellite,rover,trace-profiling,mysql-monitor,postgresql-monitor,nginx-monitor,apisix-monitor,grafana,elasticsearch-monitor,rabbitmq-monitor,mongodb-monitor,r3,rocketmq-monitor,pulsar-monitor,activemq-monitor
+{{- end }}
+{{- end }}

--- a/deploy/platform/kubernetes/templates/feature-agent/resources.yaml
+++ b/deploy/platform/kubernetes/templates/feature-agent/resources.yaml
@@ -357,6 +357,89 @@ data:
           root /app/build;
           index index.html;
         }
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: activemq-config
+  namespace: {{ .Values.sampleServices.namespace }}
+  labels:
+    app: activemq-config
+data:
+  activemq: |
+    <beans
+    xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="${ACTIVEMQ_BROKER_NAME}" dataDirectory="${activemq.data}">
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" >
+                  <pendingMessageLimitStrategy>
+                    <constantPendingMessageLimitStrategy limit="1000"/>
+                  </pendingMessageLimitStrategy>
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+        <transportConnectors>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+      </broker>
+      <import resource="jetty.xml"/>
+    </beans>
+  config: |
+    startDelaySeconds: 10
+    hostPort: localhost:1616
+    ssl: false
+    lowercaseOutputName: false
+    lowercaseOutputLabelNames: false
+    includeObjectNames: ["org.apache.activemq:*","java.lang:type=OperatingSystem","java.lang:type=GarbageCollector,*","java.lang:type=Threading","java.lang:type=Runtime","java.lang:type=Memory","java.lang:name=*"]
+    excludeObjectNames: ["org.apache.activemq:type=ColumnFamily,*"]
+    autoExcludeObjectNameAttributes: true
+    excludeObjectNameAttributes:
+      "java.lang:type=OperatingSystem":
+        - "ObjectName"
+      "java.lang:type=Runtime":
+        - "ClassPath"
+        - "SystemProperties"
+    rules:
+    - pattern: ".*"
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -449,6 +532,13 @@ spec:
         - name: activemq
           image: rmohr/activemq:5.15.9
           imagePullPolicy: IfNotPresent
+          env:
+            - name: ACTIVEMQ_SUNJMX_START
+              value: "-Dcom.sun.management.jmxremote.port=1616 -Dcom.sun.management.jmxremote.rmi.port=1616 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+            - name: ACTIVEMQ_BROKER_NAME
+              value: "activemq-broker"
+            - name: ACTIVEMQ_OPTS
+              value: "-Xmx128m -Xms128m"
           resources:
             limits:
               cpu: 100m
@@ -456,6 +546,33 @@ spec:
             requests:
               cpu: 100m
               memory: "128Mi"
+          volumeMounts:
+            - name: activemq-config
+              mountPath: /opt/activemq/conf/activemq.xml
+              subPath: activemq
+        {{- if .Values.features.activemqMonitor.enabled }}
+        - name: activemq-exporter
+          image: bitnami/jmx-exporter:0.20.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5556
+              name: metrics
+          resources:
+            limits:
+              cpu: 100m
+              memory: "256Mi"
+            requests:
+              cpu: 100m
+              memory: "128Mi"
+          volumeMounts:
+            - name: activemq-config
+              mountPath: /opt/bitnami/jmx-exporter/example_configs/httpserver_sample_config.yml
+              subPath: config
+        {{- end }}
+      volumes:
+        - name: activemq-config
+          configMap:
+            name: activemq-config
 ---
 
 apiVersion: v1

--- a/deploy/platform/kubernetes/templates/otel-collector-config.yaml
+++ b/deploy/platform/kubernetes/templates/otel-collector-config.yaml
@@ -41,6 +41,7 @@ data:
             {{- include "opentelemetry-config-mongodb-monitor" . | indent 12 }}
             {{- include "opentelemetry-config-rocketmq-monitor" . | indent 12 }}
             {{- include "opentelemetry-config-pulsar-monitor" . | indent 12 }}
+            {{- include "opentelemetry-config-activemq-monitor" . | indent 12 }}
 
     exporters:
       otlp:

--- a/deploy/platform/kubernetes/values.yaml
+++ b/deploy/platform/kubernetes/values.yaml
@@ -40,7 +40,7 @@ skywalking:
       # @feature: istiod-monitor; enable rules to analyze Istio control plane metrics
       # @feature: mysql; enable mysql rules to analyze MySQL metrics
       # @feature: apisix-monitor; enable APISIX rules to analyze APISIX metrics
-      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,oap,k8s/*,istio-controlplane,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/*,nginx/*,rocketmq/*,pulsar/*
+      SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES: vm,oap,k8s/*,istio-controlplane,mysql/*,postgresql/*,apisix,elasticsearch/*,rabbitmq/*,mongodb/*,nginx/*,rocketmq/*,pulsar/*,activemq/*
       SW_TELEMETRY: prometheus # @feature: so11y; expose the metrics of self o11y through prometheus
       SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS: "mx-mesh,persistence" # @feature: als; enable mesh analyzer (mx-mesh) to analyze ALS logs
       K8S_SERVICE_NAME_RULE: "mesh-svr::${service.metadata.name}.${service.metadata.namespace}"
@@ -357,4 +357,7 @@ features:
     enabled: false
     
   pulsarMonitor:
+    enabled: false
+
+  activemqMonitor:
     enabled: false

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -114,6 +114,7 @@ Currently, the features supported are:
 | `rocketmq-monitor`      | Deploy OpenTelemetry and export RocketMQ monitoring metrics to SkyWalking for analysis and display on UI.                                                                              |                                                                                                                                       |
 | `pulsar-monitor`        | Deploy OpenTelemetry and export Pulsar monitoring metrics to SkyWalking for analysis and display on UI.                                                                                |                                                                                                                                       |
 | `rabbitmq-monitor`      | Deploy OpenTelemetry and export RabbitMQ monitoring metrics to SkyWalking for analysis and display on UI.                                                                              |                                                                                                                                       |
+| `activemq-monitor`      | Deploy OpenTelemetry and export [ActiveMQ classic](https://activemq.apache.org/components/classic/) monitoring metrics to SkyWalking for analysis and display on UI.                   |                                                                                                                                       |
 
 ### Kubernetes
 


### PR DESCRIPTION
### Add ActiveMQ monitoring
- [x] Update the documentation to include this new feature.

Provides an optional ActiveMQ queue monitoring based on the recently added ActiveMQ monitoring panel.(enabled by `activemq-monitor` flag)
The ActiveMQ component is defined in the original agent service, not added here again.

After enable the activemq-monitor：
- in docker：`make deploy.docker FEATURE_FLAGS=single-node,agent,activemq-monitor`
- in k8s: `make deploy.kubernetes FEATURE_FLAGS=single-node,elasticsearch,kubernetes-monitor,activemq-monitor`
![image](https://github.com/apache/skywalking-showcase/assets/22817918/19aac097-6628-478b-9197-25dad281a579)
![image](https://github.com/apache/skywalking-showcase/assets/22817918/c8ed7837-87b0-491a-b27e-54995547a279)
![image](https://github.com/apache/skywalking-showcase/assets/22817918/eda12ca3-356b-423b-9873-6167a8217c67)
![image](https://github.com/apache/skywalking-showcase/assets/22817918/d9c50a88-605f-4cb0-b0e6-f275ae5fb9c0)




