### PR TITLE
fix: fix invalid image tag of otel-collector in docker-compose mode

### DIFF
--- a/deploy/platform/docker/docker-compose.activemq-monitor.yaml
+++ b/deploy/platform/docker/docker-compose.activemq-monitor.yaml
@@ -30,7 +30,7 @@ services:
       - sw
 
   otel-collector:
-    image: ${OTEL_COLLECTOR_IMAGE}:${OTEL_COLLECTOR_VERSION}
+    image: ${OTEL_COLLECTOR_IMAGE}:${OTEL_COLLECTOR_IMAGE_TAG}
     environment:
       SW_AGENT_COLLECTOR_BACKEND_SERVICES: ${BACKEND_SERVICE}:11800
       OTEL_TARGET_ADDREESS: amqexporter:5556


### PR DESCRIPTION
hello I found a mistake of docker image tag variable mismatch for `otel-collector` in docker-compose mode, please fix it.

It been defined by `OTEL_COLLECTOR_IMAGE_TAG` and used by same name in many file except `docker-compose.activemq-monitor`, it used with `OTEL_COLLECTOR_VERSION`.

thank you.