### PR TITLE
Revert #190 and #189

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -49,7 +49,7 @@ SW_AGENT_NODEJS_FRONTEND_VERSION ?= 1e31bd17dcebb616163d848fc435f3a2d4822fb8
 SW_SATELLITE_IMAGE ?= ghcr.io/apache/skywalking-satellite/skywalking-satellite
 SW_SATELLITE_IMAGE_TAG ?= v261daa37cfe4abbae6e12ef5706a941b4357b815
 
-SW_ROVER_IMAGE ?= ghcr.io/apache/skywalking-rover/skywalking-rover:2331dbe091343b9ebb2c74a8c6500af80274fb07
+SW_ROVER_IMAGE ?= ghcr.io/apache/skywalking-rover/skywalking-rover:e0fc8f7c72a8b57dab6ea9552d7be2b40b134fe8
 
 SWCK_OPERATOR_IMAGE ?= docker.io/apache/skywalking-swck
 SWCK_OPERATOR_IMAGE_TAG ?= v0.7.0

--- a/Makefile.in
+++ b/Makefile.in
@@ -49,7 +49,7 @@ SW_AGENT_NODEJS_FRONTEND_VERSION ?= 1e31bd17dcebb616163d848fc435f3a2d4822fb8
 SW_SATELLITE_IMAGE ?= ghcr.io/apache/skywalking-satellite/skywalking-satellite
 SW_SATELLITE_IMAGE_TAG ?= v261daa37cfe4abbae6e12ef5706a941b4357b815
 
-SW_ROVER_IMAGE ?= ghcr.io/apache/skywalking-rover/skywalking-rover:e0fc8f7c72a8b57dab6ea9552d7be2b40b134fe8
+SW_ROVER_IMAGE ?= ghcr.io/apache/skywalking-rover/skywalking-rover:2331dbe091343b9ebb2c74a8c6500af80274fb07
 
 SWCK_OPERATOR_IMAGE ?= docker.io/apache/skywalking-swck
 SWCK_OPERATOR_IMAGE_TAG ?= v0.7.0

--- a/deploy/platform/kubernetes/templates/feature-r3/resources.yaml
+++ b/deploy/platform/kubernetes/templates/feature-r3/resources.yaml
@@ -74,7 +74,7 @@ spec:
             - name: r3-load
               image: curlimages/curl
               command: ["/bin/sh"]
-              args: ["-c", "for i in $(seq 1 200); do curl http://rating/songs/$i/reviews/$((i+1)); sleep 1; done;"]
+              args: ["-c", "for i in $(seq 1 200); do curl http://rating/songs/$i/reviews/$((i+1)); sleep 1; done; curl -X POST http://localhost:15000/quitquitquit;"]
               securityContext:
                 capabilities:
                   add:

--- a/deploy/platform/kubernetes/templates/feature-r3/resources.yaml
+++ b/deploy/platform/kubernetes/templates/feature-r3/resources.yaml
@@ -69,9 +69,6 @@ spec:
     spec:
       template:
         spec:
-          metadata:
-            annotations:
-              sidecar.istio.io/inject: "false"
           shareProcessNamespace: true
           containers:
             - name: r3-load


### PR DESCRIPTION
Turns out the annotation is not added and the r3-load pod can’t be terminated, I’m going to revert this for now. @mrproliu if you want please find the correct way to avoid injecting the sidecar.

<img width="1627" alt="image" src="https://github.com/user-attachments/assets/198922c0-edb7-47f0-a21d-c8b32834f037">
