### PR TITLE
Fix showcase local booting

### DIFF
--- a/deploy/platform/kubernetes/Makefile.in
+++ b/deploy/platform/kubernetes/Makefile.in
@@ -24,4 +24,4 @@ CILIUM_SERVICES_NAMESPACE ?= cilium-services
 RELEASE ?= demo
 AGENTLESS ?= false
 
-FEATURE_FLAGS ?= java-agent-injector,cluster,elasticsearch,kubernetes-monitor,so11y,vm-monitor,als,event,istiod-monitor,satellite,rover,trace-profiling,mysql-monitor,postgresql-monitor,nginx-monitor,apisix-monitor,grafana,elasticsearch-monitor,rabbitmq-monitor,mongodb-monitor,r3,rocketmq-monitor,pulsar-monitor,activemq-monitor
+FEATURE_FLAGS ?= java-agent-injector,cluster,kubernetes-monitor,so11y,vm-monitor,als,event,istiod-monitor,satellite,rover,trace-profiling,mysql-monitor,postgresql-monitor,nginx-monitor,apisix-monitor,grafana,elasticsearch-monitor,rabbitmq-monitor,mongodb-monitor,r3,rocketmq-monitor,pulsar-monitor,activemq-monitor


### PR DESCRIPTION
With elasticsearch in default feature flags, the storage is switched to elasticsearch rather than the preferred banyandb.

Meanwhile, why elasticsearch version is not being set by default(customization is another storage)?