### PR TITLE
Fix wrong base node image version

### DIFF
--- a/services/app/server/Dockerfile
+++ b/services/app/server/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM node:18
+FROM node:20
 
 ARG SW_AGENT_NODEJS_BACKEND_VERSION
 

--- a/services/app/server/Dockerfile
+++ b/services/app/server/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM node:10
+FROM node:18
 
 ARG SW_AGENT_NODEJS_BACKEND_VERSION
 

--- a/services/app/server/Dockerfile.agentless
+++ b/services/app/server/Dockerfile.agentless
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM node:10
+FROM node:18
 
 WORKDIR /app
 

--- a/services/app/server/Dockerfile.agentless
+++ b/services/app/server/Dockerfile.agentless
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM node:18
+FROM node:20
 
 WORKDIR /app
 


### PR DESCRIPTION
Following https://github.com/apache/skywalking-showcase/commit/b7afcf64af13b4cda7d5225be6ff19aa1768ffdd, and the CI failure: https://github.com/apache/skywalking-showcase/actions/runs/28563139491. Seems like the base node image version should be updated. 